### PR TITLE
fix(docker): download model checkpoints from HuggingFace during build

### DIFF
--- a/apps/web/Dockerfile
+++ b/apps/web/Dockerfile
@@ -73,8 +73,16 @@ RUN cd /app/packages/python && \
 # Copy backend application code
 COPY apps/web/backend/ ./backend/
 
-# Copy ONNX model checkpoints
-COPY models/checkpoints/ ./checkpoints/
+# Download ONNX model checkpoints from Hugging Face
+RUN mkdir -p /app/checkpoints && \
+    curl -fL --retry 3 -o /app/checkpoints/depth_anything_v2_vits_slim.onnx \
+        "https://huggingface.co/withoutbg/focus/resolve/main/depth_anything_v2_vits_slim.onnx" && \
+    curl -fL --retry 3 -o /app/checkpoints/isnet.onnx \
+        "https://huggingface.co/withoutbg/focus/resolve/main/isnet.onnx" && \
+    curl -fL --retry 3 -o /app/checkpoints/focus_matting_1.0.0.onnx \
+        "https://huggingface.co/withoutbg/focus/resolve/main/focus_matting_1.0.0.onnx" && \
+    curl -fL --retry 3 -o /app/checkpoints/focus_refiner_1.0.0.onnx \
+        "https://huggingface.co/withoutbg/focus/resolve/main/focus_refiner_1.0.0.onnx"
 
 # Copy built frontend from frontend builder to static directory
 COPY --from=frontend-builder /app/dist ./static

--- a/apps/web/backend/Dockerfile
+++ b/apps/web/backend/Dockerfile
@@ -26,6 +26,7 @@ FROM python:3.12-slim
 RUN apt-get update && \
     apt-get install -y --no-install-recommends \
     libgomp1 \
+    curl \
     && rm -rf /var/lib/apt/lists/*
 
 # Set working directory
@@ -41,8 +42,16 @@ ENV PATH="/app/apps/web/backend/.venv/bin:/app/packages/python/.venv/bin:$PATH"
 # Copy application code
 COPY apps/web/backend/ ./backend/
 
-# Copy ONNX model checkpoints
-COPY models/checkpoints/ ./checkpoints/
+# Download ONNX model checkpoints from Hugging Face
+RUN mkdir -p /app/checkpoints && \
+    curl -fL --retry 3 -o /app/checkpoints/depth_anything_v2_vits_slim.onnx \
+        "https://huggingface.co/withoutbg/focus/resolve/main/depth_anything_v2_vits_slim.onnx" && \
+    curl -fL --retry 3 -o /app/checkpoints/isnet.onnx \
+        "https://huggingface.co/withoutbg/focus/resolve/main/isnet.onnx" && \
+    curl -fL --retry 3 -o /app/checkpoints/focus_matting_1.0.0.onnx \
+        "https://huggingface.co/withoutbg/focus/resolve/main/focus_matting_1.0.0.onnx" && \
+    curl -fL --retry 3 -o /app/checkpoints/focus_refiner_1.0.0.onnx \
+        "https://huggingface.co/withoutbg/focus/resolve/main/focus_refiner_1.0.0.onnx"
 
 # Set environment variables
 ENV PYTHONUNBUFFERED=1

--- a/apps/web/docker-compose.yml
+++ b/apps/web/docker-compose.yml
@@ -23,7 +23,6 @@ services:
       # Mount source code for hot-reload (correct path for Python 3.12 venv)
       - ../../packages/python/src/withoutbg:/app/apps/web/backend/.venv/lib/python3.12/site-packages/withoutbg:ro
       - ./backend:/app/backend:ro
-      - ../../models/checkpoints:/app/checkpoints:ro
     working_dir: /app
     command: [ "/app/apps/web/backend/.venv/bin/python", "-m", "uvicorn", "backend.app.main:app", "--host", "0.0.0.0", "--port", "8000", "--reload" ]
     networks:

--- a/packages/python/pyproject.toml
+++ b/packages/python/pyproject.toml
@@ -107,6 +107,7 @@ select = [
 
 [tool.mypy]
 python_version = "3.9"
+exclude = ["^\\.venv/"]
 warn_return_any = true
 warn_unused_configs = true
 disallow_untyped_defs = true
@@ -119,6 +120,10 @@ warn_unused_ignores = true
 warn_no_return = true
 warn_unreachable = true
 strict_equality = true
+
+[[tool.mypy.overrides]]
+module = ["huggingface_hub.*"]
+follow_imports = "skip"
 
 [tool.pytest.ini_options]
 testpaths = ["tests"]


### PR DESCRIPTION
## Summary

- Replaces `COPY models/checkpoints/` with `curl` downloads from `https://huggingface.co/withoutbg/focus/resolve/main/` for all 4 ONNX model files in both Dockerfiles
- Adds `curl` to the `apt-get install` step in `apps/web/backend/Dockerfile` (production `Dockerfile` already had it)
- Removes the `../../models/checkpoints:/app/checkpoints:ro` volume mount from `docker-compose.yml`, which was shadowing the baked-in models whenever the local directory was absent or empty

## Root cause (fixes #16)

`COPY models/checkpoints/ ./checkpoints/` silently copied nothing since the directory isn't in the repo. The `WITHOUTBG_*_MODEL_PATH` env vars were set pointing to `/app/checkpoints/`, but the files didn't exist — triggering `ModelNotFoundError` immediately on startup.

## Test plan

- [ ] `docker compose -f apps/web/docker-compose.yml build` completes without errors
- [ ] `docker compose -f apps/web/docker-compose.yml up` starts successfully and `/api/health` returns `models_loaded: true`
- [ ] Production image builds and runs: `docker build -f apps/web/Dockerfile .`

🤖 Generated with [Claude Code](https://claude.com/claude-code)