### PR TITLE
fix(ci): upgrade setuptools before pip-audit

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -85,6 +85,7 @@ jobs:
     - name: Install package and security tools
       run: |
         python -m pip install --upgrade pip
+        pip install --upgrade "setuptools>=83.0.0"  # PYSEC-2026-3447
         pip install -e ".[dev]"
         pip install bandit[toml] pip-audit
 


### PR DESCRIPTION
## Summary
- Security CI failed because `pip-audit` found [PYSEC-2026-3447](https://github.com/pypa/setuptools/security/advisories/GHSA-h35f-9h28-mq5c) in `setuptools 79.0.1` (fixed in `83.0.0`).
- Upgrade setuptools in the security job before running `pip-audit`.

## Test plan
- [x] Confirmed locally with Python 3.13: `pip-audit` is clean after `setuptools>=83.0.0`
- [ ] CI security job passes on this PR


Made with [Cursor](https://cursor.com)