### PR TITLE
docs: host AlphaMate README video on GitHub CDN

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # withoutbg
 
-<video src="docs/alphamate_reveal.mp4" width="720" autoplay loop muted playsinline>
-  <a href="docs/alphamate_reveal.mp4">AlphaMate reveal — background removal in action</a>
+<video src="https://github.com/user-attachments/assets/8fd50d46-caa5-48a7-ae58-17324636dc95" width="720" autoplay loop muted playsinline>
+  <a href="https://github.com/user-attachments/assets/8fd50d46-caa5-48a7-ae58-17324636dc95">AlphaMate reveal — background removal in action</a>
 </video>
 
 **One clean alpha. Zero hassle. Drop the background in three lines of Python.**


### PR DESCRIPTION
## Summary
- Empty commit to open a PR where we can upload `docs/alphamate_reveal.mp4` via the GitHub UI
- Goal: get a `https://github.com/user-attachments/assets/...` URL so the README `<video>` embed works

https://github.com/user-attachments/assets/8fd50d46-caa5-48a7-ae58-17324636dc95


## Test plan
- [ ] Drag `docs/alphamate_reveal.mp4` into a PR comment and copy the attachment URL
- [ ] Point the README `<video src="...">` at that URL
- [ ] Confirm the video plays on the repo README preview


Made with [Cursor](https://cursor.com)